### PR TITLE
Adds coveragerc to prevent tests running on tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+source = .
+omit = ./venv/*,./tests/*,*tests*,*apps.py,*manage.py,*__init__.py,*migrations*,*asgi*,*wsgi*,*admin.py,*urls.py
+
+[report]
+omit = ./venv/*,./tests/*,*tests*,*apps.py,*manage.py,*__init__.py,*migrations*,*asgi*,*wsgi*,*admin.py,*urls.py


### PR DESCRIPTION
I found pytest was testing all python files, including venv and test files themselves. This prevents this.