### PR TITLE
Make action run on pull request

### DIFF
--- a/.github/workflows/lint-fix.yml
+++ b/.github/workflows/lint-fix.yml
@@ -1,5 +1,5 @@
 name: Lint and format Ruff
-on: [push]
+on: [pull_request]
 permissions:
     checks: write
     contents: write
@@ -16,7 +16,5 @@ jobs:
                 args: "--version"
             - name: Ruff check
               run: ruff check
-              continue-on-error: true
             - name: Ruff format
               run: ruff format --diff
-              continue-on-error: true


### PR DESCRIPTION
The action was being run too many times. It should only be run when actually being committed to main.

Also removes `continue-on-error` because I wasn't being notified of errors.