### PR TITLE
Load schema on `docker compose up`

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -13,4 +13,4 @@ services:
       - 5432:5432
     volumes:
       - apis_db_data:/var/lib/postgresql/data
-      #- ./seeds/seed_data.sql:/docker-entrypoint-initdb.d/seed_data.sql
+      - ./sql/schema.sql:/docker-entrypoint-initdb.d/schema.sql


### PR DESCRIPTION
Changes the docker `compose.yml` file to load the SQL schema on `docker compose up`. This means that the dev db will always have the correct schema and doesn't need to be manually seeded.